### PR TITLE
[FIX] web_gantt: compatibility with bridge module

### DIFF
--- a/web_gantt/static/src/js/gantt_renderer.js
+++ b/web_gantt/static/src/js/gantt_renderer.js
@@ -232,6 +232,7 @@ return AbstractRenderer.extend({
         };
 
         var scale = this.state.scale;
+        debugger;
         var scaleInfo = this.cellPrecisions[this.state.scale];
         var result = [{unit: scale, step: 1, format: scaleMainFormat[scale]}];
         switch (scale) {

--- a/web_gantt/static/src/js/gantt_row.js
+++ b/web_gantt/static/src/js/gantt_row.js
@@ -1,0 +1,13 @@
+odoo.define('web_gantt.GanttRow', function (require) {
+"use strict";
+
+var Widget = require('web.Widget');
+
+var GanttRow = Widget.extend({
+    template: 'GanttView.Row',
+    // empty class for compatibility with module extending the gantt view (entreprise module)
+});
+
+return GanttRow;
+
+});

--- a/web_gantt/static/src/js/gantt_view.js
+++ b/web_gantt/static/src/js/gantt_view.js
@@ -79,10 +79,11 @@ var GanttView = BasicView.extend({
         var precisionAttrs = arch.attrs.precision ? pyUtils.py_eval(arch.attrs.precision) : {};
         var cellPrecisions = {};
         _.each(this.SCALES, function (vals, key) {
+            // set default value
+            var defaultUntiPrecision = vals.defaultUnitPrecision.split(':');
+            cellPrecisions[key] = {unit: defaultUntiPrecision[0], precision: defaultUntiPrecision[1]};
+
             if (precisionAttrs[key]) {
-                // set default value
-                var defaultUntiPrecision = vals.defaultUnitPrecision.split(':');
-                cellPrecisions[key] = {unit: defaultUntiPrecision[0], precision: defaultUntiPrecision[1]};
 
                 // set the unit from attrs
                 var unitPrecision = precisionAttrs[key].split(':'); // hour:half

--- a/web_gantt/static/src/xml/web_gantt.xml
+++ b/web_gantt/static/src/xml/web_gantt.xml
@@ -22,4 +22,7 @@
         </button>
     </div>
 
+    <div t-name="GanttView.Row" t-attf-class="row no-gutters o_gantt_row">
+    </div>
+
 </templates>

--- a/web_gantt/views/assets.xml
+++ b/web_gantt/views/assets.xml
@@ -8,6 +8,7 @@
             <script type="text/javascript" src="/web_gantt/static/src/js/gantt_model.js"/>
             <script type="text/javascript" src="/web_gantt/static/src/js/gantt_controller.js"/>
             <script type="text/javascript" src="/web_gantt/static/src/js/gantt_view.js"/>
+            <script type="text/javascript" src="/web_gantt/static/src/js/gantt_row.js"/>
         </xpath>
     </template>
 </data>


### PR DESCRIPTION
This commit
- create empty class for gantt row, so other module
(enterprise) that are extending that class does not crash
- makes sure a default precision always exist for a unit,
even if not defined on the view itself.

Most relevant example is hr_gantt module.