### PR TITLE
[ADD] budge, buget_analytic: new modules

### DIFF
--- a/budget/__init__.py
+++ b/budget/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import models
+from . import report

--- a/budget/__manifest__.py
+++ b/budget/__manifest__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': 'Budget',
+    'category': 'Budget',
+    'description': """
+Use budgets to compare actual with expected revenues and costs
+--------------------------------------------------------------
+""",
+    'depends': ['mail'],
+    'data': [
+        'security/budget_security.xml',
+        'security/ir.model.access.csv',
+        'views/budget_line_views.xml',
+        'views/budget_views.xml',
+        'report/budget_print_report_templates.xml',
+        'report/budget_print_reports.xml',
+    ],
+    'demo': ['data/budget_demo.xml'],
+    'application': True,
+    'license': 'LGPL-3',
+    'assets': {
+        'web.report_assets_common': [
+            'budget/static/src/scss/budget_report.scss',
+        ],
+    }
+}

--- a/budget/data/budget_demo.xml
+++ b/budget/data/budget_demo.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <!-- Budgets -->
+   <data noupdate="1">
+
+        <!-- Optimistic -->
+        <record id="crossovered_budget_budgetoptimistic0" model="budget.budget">
+            <field eval="'Budget '+str(datetime.now().year+1)+': Optimistic'" name="name"/>
+            <field name="user_id" ref="base.user_admin"/>
+            <field eval="str(datetime.now().year+1)+'-01-01'" name="date_from"/>
+            <field eval="str(datetime.now().year+1)+'-12-31'" name="date_to"/>
+         </record>
+         <record id="budget_line_analytic_admin" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">-35000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait1" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">10000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait2" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">10000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait3" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">12000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait4" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">15000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait5" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">15000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait6" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">15000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait7" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">13000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait8" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">9000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait9" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">8000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait10" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetoptimistic0"/>
+            <field name="planned_amount">15000</field>
+            <field name="mode">manual</field>
+         </record>
+
+        <!-- pessimistic-->
+        <record id="crossovered_budget_budgetpessimistic0" model="budget.budget">
+            <field eval="'Budget '+str(datetime.now().year+1)+': Pessimistic'" name="name"/>
+            <field name="user_id" ref="base.user_admin"/>
+            <field eval="str(datetime.now().year+1)+'-01-01'" name="date_from"/>
+            <field eval="str(datetime.now().year+1)+'-12-31'" name="date_to"/>
+         </record>
+
+         <record id="budget_line_analytic_admin_pessim" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">-55000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim1" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">9000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim2" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">8000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim3" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">10000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim4" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">14000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim5" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">16000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim6" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">13000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim7" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">10000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim8" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">8000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim9" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">7000</field>
+            <field name="mode">manual</field>
+         </record>
+         <record id="budget_line_analytic_agrolait_pessim10" model="budget.budget.line">
+            <field name="name">Line</field>
+            <field name="budget_id" ref="crossovered_budget_budgetpessimistic0" />
+            <field name="planned_amount">12000</field>
+            <field name="mode">manual</field>
+         </record>
+    </data>
+</odoo>

--- a/budget/models/__init__.py
+++ b/budget/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import budget

--- a/budget/models/budget.py
+++ b/budget/models/budget.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class Budget(models.Model):
+    _name = 'budget.budget'
+    _description = "Budget"
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+
+    name = fields.Char('Budget Name', required=True, states={'done': [('readonly', True)]}, tracking=True)
+    user_id = fields.Many2one('res.users', 'Responsible', default=lambda self: self.env.user)
+    date_from = fields.Date('Start Date', required=True, states={'done': [('readonly', True)]})
+    date_to = fields.Date('End Date', required=True, states={'done': [('readonly', True)]})
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('confirm', 'Confirmed'),
+        ('done', 'Done'),
+        ('cancel', 'Cancelled'),
+    ], 'Status', default='draft', index=True, required=True, readonly=True, copy=False, tracking=True)
+    category_ids = fields.One2many('budget.category', 'budget_id', 'Categories', states={'done': [('readonly', True)]}, copy=True)
+
+    budget_line_ids = fields.One2many('budget.budget.line', 'budget_id', 'Budget Lines', states={'done': [('readonly', True)]}, copy=True)
+    planned_credit_amount = fields.Monetary("Total Credit Planned Amount", compute='_compute_planned_amount')
+    planned_debit_amount = fields.Monetary("Total Debit Planned Amount", compute='_compute_planned_amount')
+    practical_credit_amount = fields.Monetary("Total Credit Practical Amount", compute='_compute_practical_amount')
+    practical_debit_amount = fields.Monetary("Total Debit Practical Amount", compute='_compute_practical_amount')
+
+    currency_id = fields.Many2one('res.currency', related='company_id.currency_id', readonly=True)
+    company_id = fields.Many2one('res.company', 'Company', required=True, store=True, default=lambda self: self.env.user.company_id)
+
+    @api.depends('budget_line_ids.planned_amount')
+    def _compute_planned_amount(self):
+        for budget in self:
+            budget.planned_credit_amount = sum(budget.budget_line_ids.filtered(lambda l: l.planned_amount > 0.0).mapped('planned_amount'))
+            budget.planned_debit_amount = sum(budget.budget_line_ids.filtered(lambda l: l.planned_amount < 0.0).mapped('planned_amount'))
+
+    @api.depends('budget_line_ids.practical_amount')
+    def _compute_practical_amount(self):
+        for budget in self:
+            budget.practical_credit_amount = sum(budget.budget_line_ids.filtered(lambda l: l.practical_amount > 0.0).mapped('practical_amount'))
+            budget.practical_debit_amount = sum(budget.budget_line_ids.filtered(lambda l: l.practical_amount < 0.0).mapped('practical_amount'))
+
+    def action_budget_confirm(self):
+        self.write({'state': 'confirm'})
+
+    def action_budget_draft(self):
+        self.write({'state': 'draft'})
+
+    def action_budget_cancel(self):
+        self.write({'state': 'cancel'})
+
+    def action_budget_done(self):
+        self.write({'state': 'done'})
+
+
+class BudgetCategory(models.Model):
+    _name = 'budget.category'
+    _description = "Budget Category"
+    _order = 'sequence, name'
+
+    name = fields.Char("Name", required=True)
+    color = fields.Integer("Color", default=5)
+    budget_id = fields.Many2one('budget.budget', 'Budget', ondelete='cascade', index=True, required=True)
+    sequence = fields.Integer("Sequence", default=10)
+    company_id = fields.Many2one(related='budget_id.company_id', store=True)
+
+
+class BudgetLine(models.Model):
+    _name = 'budget.budget.line'
+    _description = "Budget Line"
+    _order = 'budget_id, sequence'
+
+    name = fields.Char("Name", required=True)
+    budget_id = fields.Many2one('budget.budget', 'Budget', ondelete='cascade', index=True, required=True)
+    budget_state = fields.Selection(related='budget_id.state', string='Budget State', store=True, readonly=True)
+    category_id = fields.Many2one('budget.category', "Category", domain="[('budget_id', '=', budget_id)]")
+    sequence = fields.Integer("Sequence", default=10)
+    description = fields.Text('Note')
+    mode = fields.Selection([
+        ('manual', 'Manual'),
+    ], required=True, default='manual')
+
+    planned_amount = fields.Monetary(
+        'Planned Amount', required=True,
+        help="Amount you plan to earn/spend. Record a positive amount if it is a revenue and a negative amount if it is a cost.")
+    practical_amount = fields.Monetary(
+        compute='_compute_practical_amount',
+        inverse='_inverse_practical_amount',
+        string='Practical Amount',
+        help="Amount really earned/spent."
+    )
+    practical_amount_manual = fields.Monetary("Manual Pratical Amount")
+    practical_amount_readonly = fields.Boolean(compute='_compute_practical_amount_readonly')
+
+    percentage = fields.Float(
+        compute='_compute_percentage', string='Achievement',
+        help="Comparison between practical and theoretical amount. This measure tells you if you are below or over budget.")
+    is_above_budget = fields.Boolean(compute='_compute_is_above_budget')
+    company_id = fields.Many2one('res.company', related='budget_id.company_id', string='Company', store=True, readonly=True)
+    currency_id = fields.Many2one('res.currency', related='company_id.currency_id', readonly=True)
+
+    @api.depends('mode', 'practical_amount_manual')
+    def _compute_practical_amount(self):
+        for line in self:
+            if line.mode == 'manual':
+                line.practical_amount = line.practical_amount_manual or 0.0
+            else:
+                line.practical_amount = None
+
+    @api.depends('mode')
+    def _compute_practical_amount_readonly(self):
+        for line in self:
+            line.practical_amount_readonly = bool(line.mode != 'manual')
+
+    @api.depends('planned_amount', 'practical_amount')
+    def _compute_percentage(self):
+        for line in self:
+            if line.planned_amount != 0.0:
+                line.percentage = float((line.practical_amount or 0.0) / line.planned_amount)
+            else:
+                line.percentage = 0.0
+
+    @api.depends('planned_amount', 'practical_amount')
+    def _compute_is_above_budget(self):
+        for line in self:
+            if line.planned_amount >= 0:
+                line.is_above_budget = line.practical_amount > line.planned_amount
+            else:
+                line.is_above_budget = line.practical_amount < line.planned_amount
+
+    @api.onchange('practical_amount_manual')
+    def _inverse_practical_amount(self):
+        for line in self:
+            if line.mode == 'manual':
+                line.practical_amount_manual = line.practical_amount
+            else:
+                line.practical_amount_manual = 0.0
+
+    @api.constrains('category_id', 'budget_id')
+    def _check_catergory(self):
+        for line in self:
+            if line.category_id and line.category_id.budget_id != line.budget_id:
+                raise ValidationError(_("Budget mismatch."))
+
+    @api.constrains('category_id', 'company_id')
+    def _check_company(self):
+        for line in self:
+            if line.category_id and line.category_id.company_id != line.company_id:
+                raise ValidationError(_("Company mismatch."))
+
+    # ------------------------------------------------------------------
+    # Business Methods
+    # ------------------------------------------------------------------
+
+    def _get_lines_grouped_by_category(self):
+        data = {}
+        for line in self:
+            data.setdefault(line.category_id, self.env['budget.budget.line'])
+            data[line.category_id] |= line
+        return data

--- a/budget/report/budget_print_report_templates.xml
+++ b/budget/report/budget_print_report_templates.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="budget_report_template_page">
+        <t t-call="web.external_layout">
+            <div class="page o_budget_report">
+                <h2 class="text-center">
+                    <span t-field="o.name"/>
+                </h2>
+                <h4 class="text-center">
+                    <span t-field="o.date_from"/> - <span t-field="o.date_to"/>
+                </h4>
+
+                <div class="row mt-5">
+                    <div class="col-6">
+                        <h4 class="text-center">Expenses</h4>
+                        <t t-set="lines_by_category" t-value="o.budget_line_ids.filtered(lambda l: l.planned_amount &lt; 0.0)._get_lines_grouped_by_category()"/>
+                        <t t-call="budget.budget_report_template_table_lines"/>
+                    </div>
+                    <div class="col-6">
+                        <h4 class="text-center">Incomes</h4>
+                        <t t-set="lines_by_category" t-value="o.budget_line_ids.filtered(lambda l: l.planned_amount &gt;= 0.0)._get_lines_grouped_by_category()"/>
+                        <t t-call="budget.budget_report_template_table_lines"/>
+                    </div>
+                </div>
+
+                <div class="row mt-5">
+                    <div class="col-6">
+                        <table class="table h5">
+                            <tr>
+                                <td>Total Expenses</td>
+                                <td><span t-field="o.planned_debit_amount"/></td>
+                                <td><span t-field="o.practical_debit_amount"/></td>
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="col-6">
+                        <table class="table h5">
+                            <tr>
+                                <td>Total Incomes</td>
+                                <td><span t-field="o.planned_credit_amount"/></td>
+                                <td><span t-field="o.practical_credit_amount"/></td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+                <div class="row mt-5">
+                    <div class="col-6 offset-6">
+                        <table class="table h4">
+                            <tr>
+                                <td>Planned Total</td>
+                                <td><span t-esc="o.planned_credit_amount + o.planned_debit_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>
+                            </tr>
+                            <tr>
+                                <td>Practical Total</td>
+                                <td><span t-esc="o.practical_credit_amount + o.practical_debit_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+
+    <template id="budget_report_template_table_lines">
+        <t t-foreach="sorted(lines_by_category)" t-as="category">
+            <table class="table">
+                <thead t-attf-class="table">
+                    <tr t-attf-class="o_budget_report_header_color_#{str(category.color)}">
+                        <th scope="col" class="col-md-4 align-middle text-uppercase">
+                            <t t-esc="category.name"/>
+                        </th>
+                        <th scope="col" class="align-middle">Planned</th>
+                        <th scope="col" class="align-middle">Practical</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <t t-foreach="lines_by_category[category]" t-as="line">
+                        <tr t-attf-class="text o_budget_report_text_color_#{str(category.color)}">
+                            <td><t t-esc="line.name"/></td>
+                            <td><span t-field="line.planned_amount"/></td>
+                            <td><span t-field="line.practical_amount"/></td>
+                        </tr>
+                    </t>
+                    <tr t-attf-class="text o_budget_report_text_color_#{str(category.color)}">
+                        <td><b>Total</b></td>
+                        <td><b t-esc="sum(lines_by_category[category].mapped('planned_amount'))" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>
+                        <td><b t-esc="sum(lines_by_category[category].mapped('practical_amount'))" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>
+                    </tr>
+                </tbody>
+            </table>
+        </t>
+    </template>
+
+    <template id="budget_report_template">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-call="budget.budget_report_template_page" t-lang="lang"/>
+            </t>
+        </t>
+    </template>
+
+</odoo>

--- a/budget/report/budget_print_reports.xml
+++ b/budget/report/budget_print_reports.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="budget_buget_action_report" model="ir.actions.report">
+        <field name="name">Budget Report</field>
+        <field name="model">budget.budget</field>
+        <field name="report_type">qweb-html</field>
+        <field name="report_name">budget.budget_report_template</field>
+        <field name="report_file">budget.budget_report_template</field>
+        <field name="print_report_name">'Budget: %s' % (object.name)</field>
+        <field name="binding_model_id" ref="budget.model_budget_budget"/>
+        <field name="binding_type">report</field>
+    </record>
+
+</odoo>

--- a/budget/security/budget_security.xml
+++ b/budget/security/budget_security.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="group_budget_user" model="res.groups">
+        <field name="name">User</field>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+        <field name="category_id" ref="base.module_category_budget"/>
+    </record>
+
+    <record id="group_budget_manager" model="res.groups">
+        <field name="name">Manager</field>
+        <field name="implied_ids" eval="[(4, ref('group_budget_user'))]"/>
+        <field name="category_id" ref="base.module_category_budget"/>
+    </record>
+
+    <record id="base.user_root" model="res.users">
+        <field name="groups_id" eval="[(4, ref('group_budget_manager'))]"/>
+    </record>
+
+    <record id="base.user_admin" model="res.users">
+        <field name="groups_id" eval="[(4, ref('group_budget_manager'))]"/>
+    </record>
+
+
+    <data noupdate="1">
+
+        <record id="budget_category_rule_multi_company" model="ir.rule">
+            <field name="name">Budget category multi-company</field>
+            <field name="model_id" ref="model_budget_category"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
+
+        <record id="budget_budget_rule_multi_company" model="ir.rule">
+            <field name="name">Budget multi-company</field>
+            <field name="model_id" ref="model_budget_budget"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
+
+        <record id="budget_budget_line_rule_multi_company" model="ir.rule">
+            <field name="name">Budget lines multi-company</field>
+            <field name="model_id" ref="model_budget_budget_line"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
+
+
+        <record id="budget_budget_rule_user" model="ir.rule">
+            <field name="name">Budget user: own budget</field>
+            <field name="model_id" ref="model_budget_budget"/>
+            <field name="groups" eval="[(4, ref('group_budget_user'))]"/>
+            <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+        </record>
+
+        <record id="budget_budget_line_rule_user" model="ir.rule">
+            <field name="name">Budget user : own budget line</field>
+            <field name="model_id" ref="model_budget_budget_line"/>
+            <field name="groups" eval="[(4, ref('group_budget_user'))]"/>
+            <field name="domain_force">[('budget_id.user_id', '=', user.id)]</field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+        </record>
+
+
+        <record id="budget_budget_rule_manager" model="ir.rule">
+            <field name="name">Budget manager: all budget</field>
+            <field name="model_id" ref="model_budget_budget"/>
+            <field name="groups" eval="[(4, ref('group_budget_manager'))]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+        </record>
+
+        <record id="budget_budget_line_rule_manager" model="ir.rule">
+            <field name="name">Budget manager : all budget line</field>
+            <field name="model_id" ref="model_budget_budget_line"/>
+            <field name="groups" eval="[(4, ref('group_budget_manager'))]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+        </record>
+
+    </data>
+</odoo>

--- a/budget/security/ir.model.access.csv
+++ b/budget/security/ir.model.access.csv
@@ -1,0 +1,7 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_budget_category_user,access_budget_category,model_budget_category,budget.group_budget_user,1,0,0,0
+access_budget_category_manager,access_budget_category,model_budget_category,budget.group_budget_manager,1,1,1,1
+access_budget_budget_user,access_budget_budget,model_budget_budget,budget.group_budget_manager,1,1,1,1
+access_budget_budget_manager,access_budget_budget,model_budget_budget,budget.group_budget_manager,1,1,1,1
+access_budget_budget_line_user,access_budget_budget_line,model_budget_budget_line,budget.group_budget_user,1,1,1,1
+access_budget_budget_line_manager,access_budget_budget_line,model_budget_budget_line,budget.group_budget_manager,1,1,1,1

--- a/budget/static/src/scss/budget_report.scss
+++ b/budget/static/src/scss/budget_report.scss
@@ -1,0 +1,46 @@
+.o_budget_report {
+
+    @for $size from 1 through length($o-colors) {
+        .o_budget_report_header_color_#{$size - 1} {
+            @if $size == 1 {
+                & {
+                    background-color: $o-view-background-color;
+                    color: nth($o-colors, $size);
+                    box-shadow: inset 0 0 0 1px;
+                }
+                &:focus-within {
+                    color: darken(nth($o-colors, $size), 40%) ;
+                }
+                &::after {
+                    background-color: nth($o-colors, $size);
+                }
+            } @else {
+                &, &::after {
+                    background-color: nth($o-colors, $size);
+                    color: color-contrast(nth($o-colors, $size));
+                }
+            }
+        }
+    }
+
+    @for $size from 1 through length($o-colors) {
+        .o_budget_report_text_color_#{$size - 1} {
+            @if $size == 1 {
+                & {
+                    color: nth($o-colors, $size);
+                }
+                &:focus-within {
+                    color: darken(nth($o-colors, $size), 40%) ;
+                }
+                &::after {
+                    color: nth($o-colors, $size);
+                }
+            } @else {
+                &, &::after {
+                    color: nth($o-colors, $size);
+                }
+            }
+        }
+    }
+
+}

--- a/budget/views/budget_line_views.xml
+++ b/budget/views/budget_line_views.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--
+        Budget Lines
+    -->
+
+    <record id="budget_budget_line_view_form" model="ir.ui.view">
+        <field name="name">budget.budget.line.form</field>
+        <field name="model">budget.budget.line</field>
+        <field name="arch" type="xml">
+            <form string="Budget Lines">
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name" class="oe_edit_only"/>
+                        <h2>
+                            <field name="name"/>
+                        </h2>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="budget_state" invisible="1"/>
+                            <field name="budget_id" invisible="1"/>
+                            <field name="category_id"/>
+                            <field name="mode" invisible="1"/>
+                            <field name="currency_id" invisible="1"/>
+                            <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                        </group>
+                        <group name="mode_computation" string="Practical Informations" attrs="{'invisible': [('mode', '==', 'manual')]}">
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Theorical">
+                            <field name="planned_amount"/>
+                        </group>
+                        <group string="Practical">
+                            <field name="practical_amount_readonly" invisible="1"/>
+                            <field name="practical_amount" attrs="{'readonly': [('practical_amount_readonly', '=', True)]}"/>
+                        </group>
+                    </group>
+                    <group string="Description">
+                        <field name="description" nolabel="1" colspan="2" placeholder="Note ..."/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="budget_budget_line_view_search" model="ir.ui.view">
+        <field name="name">account.budget.line.search</field>
+        <field name="model">budget.budget.line</field>
+        <field name="arch" type="xml">
+            <search string="Budget Lines">
+                <field name="budget_id"/>
+                <field name="category_id"/>
+                <filter name="filter_not_cancelled" string="Not Cancelled" domain="[('budget_state','!=','cancel')]"/>
+                <group expand="0" string="Group By">
+                    <filter name="group_budget_id" string="Budgets" domain="[]" context="{'group_by':'budget_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+</odoo>

--- a/budget/views/budget_views.xml
+++ b/budget/views/budget_views.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--
+        Budget
+    -->
+
+    <record id="budget_budget_view_list" model="ir.ui.view">
+        <field name="name">budget.budget.view.tree</field>
+        <field name="model">budget.budget</field>
+        <field name="arch" type="xml">
+            <tree decoration-info="state == 'draft'" decoration-muted="state in ('done','cancel')" string="Budget">
+                <field name="name"/>
+                <field name="date_from"/>
+                <field name="date_to"/>
+                <field name="state"/>
+                <field name="user_id"/>
+                <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="budget_budget_view_form" model="ir.ui.view">
+        <field name="name">budget.budget.view.form</field>
+        <field name="model">budget.budget</field>
+        <field name="arch" type="xml">
+            <form string="Budget">
+                <header>
+                    <button string="Confirm" name="action_budget_confirm" states="draft" type="object" class="oe_highlight"/>
+                    <button string="Done" name="action_budget_done" states="confirm" type="object" class="oe_highlight"/>
+                    <button string="Reset to Draft" name="action_budget_draft" states="cancel,done" type="object"/>
+                    <button string="Cancel Budget" name="action_budget_cancel" states="confirm" type="object"/>
+                    <field name="state" widget="statusbar" />
+                </header>
+                <sheet string="Budget">
+                    <div class="oe_title">
+                        <label for="name" class="oe_edit_only"/>
+                        <h1>
+                            <field name="name" attrs="{'readonly':[('state','!=','draft')]}" placeholder="Budget Name"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <label for="date_from" string="Period"/>
+                            <div class="o_row">
+                                <field name="date_from" widget="daterange" nolabel="1" class="oe_inline" options="{'related_end_date': 'date_to'}"/>
+                                <i class="fa fa-long-arrow-right mx-2" aria-label="Arrow icon" title="Arrow"/>
+                                <field name="date_to" widget="daterange" nolabel="1" class="oe_inline" options="{'related_start_date': 'date_from'}"/>
+                            </div>
+                            <field name="user_id" attrs="{'readonly':[('state','!=','draft')]}"/>
+                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Budget Lines">
+                            <field name="budget_line_ids" colspan="4" attrs="{'readonly':[('state','!=','draft')]}">
+                                <tree string="Budget Lines" decoration-danger="is_above_budget">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                    <field name="category_id" optional="show"/>
+                                    <field name="currency_id" invisible="1"/>
+                                    <field name="budget_id" invisible="1"/>
+                                    <field name="planned_amount" sum="Planned Amount"/>
+                                    <field name="practical_amount" sum="Practical Amount"/>
+                                    <field name="percentage" widget="percentage" optional="show"/>
+                                    <field name="is_above_budget" invisible="1"/>
+                                </tree>
+                            </field>
+                        </page>
+                        <page string="Categories">
+                            <field name="category_ids">
+                                <tree string="Categories" editable="bottom">
+                                    <field name="name"/>
+                                    <field name="color" widget="color_picker"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <record id="budget_budget_view_kanban" model="ir.ui.view">
+        <field name="name">budget.budget.kanban</field>
+        <field name="model">budget.budget</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile">
+                <field name="name"/>
+                <field name="date_from"/>
+                <field name="date_to"/>
+                <field name="user_id"/>
+                <field name="state"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div t-attf-class="oe_kanban_global_click">
+                            <div class="row mb4">
+                                <div class="col-8">
+                                    <strong>
+                                        <field name="name"/>
+                                    </strong>
+                                </div>
+                                <div class="col-4">
+                                    <span class="float-right">
+                                        <field name="state" widget="label_selection"
+                                               options="{'classes': {'draft': 'default', 'done': 'success'}}"/>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-10">
+                                    <i class="fa fa-clock-o" role="img" aria-label="Period" title="Period"/>
+                                    <t t-esc="record.date_from.value"/>-
+                                    <t t-esc="record.date_to.value"/>
+                                </div>
+                                <div class="col-2">
+                                    <span class="float-right">
+                                        <img t-att-src="kanban_image('res.users', 'image_small', record.user_id.raw_value)"
+                                             t-att-title="record.user_id.value" t-att-alt="record.user_id.value" width="24" height="24"
+                                             class="oe_kanban_avatar float-right"/>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="budget_budget_view_search" model="ir.ui.view">
+        <field name="name">budget.budget.search</field>
+        <field name="model">budget.budget</field>
+        <field name="arch" type="xml">
+            <search string="Budget">
+                <field name="name" filter_domain="[('name','ilike',self)]" string="Budget"/>
+                <field name="date_from"/>
+                <field name="date_to"/>
+                <field name="state"/>
+                <filter string="My Budget" name="assigned_to_me" domain="[('user_id', '=', uid)]"/>
+                <separator/>
+                <filter string="Draft" name="draft" domain="[('state','=','draft')]" help="Draft Budgets"/>
+                <filter string="To Approve" name="to_approve" domain="[('state','=','confirm')]" help="To Approve Budgets"/>
+                <filter string="Open Budgets" name="open" domain="[('state','not in',['cancel', 'done'])]"/>
+            </search>
+        </field>
+    </record>
+
+    <!--
+        Actions
+    -->
+
+    <record id="budget_budget_action" model="ir.actions.act_window">
+        <field name="name">Budgets</field>
+        <field name="res_model">budget.budget</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_id" ref="budget_budget_view_list"/>
+        <field name="search_view_id" ref="budget_budget_view_search"/>
+         <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Click to create a new budget.
+            </p>
+            <p>
+                Use budgets to compare actual with expected revenues and costs
+            </p>
+        </field>
+    </record>
+
+    <!--
+        Menus
+    -->
+    <menuitem
+        id="budget_menu_root"
+        name="Budget"
+        groups="base.group_user"
+        sequence="50"/>
+
+        <menuitem
+            id="budget_menu_budget"
+            name="Budgets"
+            parent="budget_menu_root"
+            action="budget_budget_action"
+            sequence="5"/>
+
+        <menuitem
+            id="budget_menu_settings"
+            name="Configuration"
+            parent="budget_menu_root"
+            sequence="15"/>
+
+</odoo>

--- a/budget_analytic/__init__.py
+++ b/budget_analytic/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/budget_analytic/__manifest__.py
+++ b/budget_analytic/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': 'Budget Analytic',
+    'category': 'Budget',
+    'description': """
+Use budgets to compare actual with expected revenues and costs
+--------------------------------------------------------------
+""",
+    'depends': ['budget', 'analytic'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/budget_line_views.xml',
+        'views/budget_analytic_tag_views.xml',
+        'views/analytic_line_views.xml',
+        'views/budget_menus.xml',
+    ],
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/budget_analytic/models/__init__.py
+++ b/budget_analytic/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import budget
+from . import analytic_line

--- a/budget_analytic/models/analytic_line.py
+++ b/budget_analytic/models/analytic_line.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models, _
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = 'account.analytic.line'
+   
+    budget_tag_ids = fields.Many2many('budget.analytic.tag', string='Budget Tags')

--- a/budget_analytic/models/budget.py
+++ b/budget_analytic/models/budget.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from random import randint
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+from odoo.osv import expression
+
+
+class BudgetAnalyticTag(models.Model):
+    _name = 'budget.analytic.tag'
+    _description = "Budget Analytic Tag"
+
+    def _get_default_color(self):
+        return randint(1, 11)
+
+    name = fields.Char('Name', required=True, translate=True)
+    color = fields.Integer(string='Color', default=_get_default_color)
+
+
+class BudgetLine(models.Model):
+    _inherit = 'budget.budget.line'
+
+    mode = fields.Selection(selection_add=[
+        ('analytic', 'Analytic'),
+    ], ondelete={'analytic': 'set default'})
+    analytic_account_id = fields.Many2one('account.analytic.account')
+    analytic_budget_tag_ids = fields.Many2many('budget.analytic.tag', string='Analytic Budget Tag')
+
+    @api.depends('analytic_account_id', 'analytic_budget_tag_ids')
+    def _compute_practical_amount(self):
+        lines_by_analytic = self.filtered(lambda l: l.mode == 'analytic')
+        lines_by_other = self.filtered(lambda l: l.mode != 'analytic')
+
+        for line in lines_by_analytic: # TODO handle multi currency
+            line.practical_amount = sum(self.env['account.analytic.line'].search(line._get_analytic_domain()).mapped('amount'))
+
+        super(BudgetLine, lines_by_other)._compute_practical_amount()
+
+    def _get_analytic_domain(self):
+        self.ensure_one()
+
+        domain = ['&', ('date', '>=', self.budget_id.date_from), ('date', '<=', self.budget_id.date_to)]
+        if self.analytic_account_id:
+            domain = expression.AND([domain, [('account_id', '=', self.analytic_account_id.id)]])
+        if self.analytic_budget_tag_ids:
+            domain = expression.AND([domain, [('budget_tag_ids', 'in', self.analytic_budget_tag_ids.ids)]])
+        return domain

--- a/budget_analytic/security/ir.model.access.csv
+++ b/budget_analytic/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+budget_analytic.access_budget_analytic_tag,access_budget_analytic_tag,budget_analytic.model_budget_analytic_tag,base.group_user,1,0,0,0
+budget_analytic.access_budget_analytic_tag_manager,access_budget_analytic_tag_manager,budget_analytic.model_budget_analytic_tag,budget.group_budget_manager,1,1,1,1
+budget_analytic.access_budget_analytic_account_user,access_account_analytic_account,analytic.model_account_analytic_account,budget.group_budget_user,1,0,0,0
+budget_analytic.access_budget_analytic_line_user,access_account_analytic_line,analytic.model_account_analytic_line,budget.group_budget_user,1,0,0,0

--- a/budget_analytic/views/analytic_line_views.xml
+++ b/budget_analytic/views/analytic_line_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="account_analytic_line_view_form" model="ir.ui.view">
+        <field name="name">account.analytic.line.form</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_line_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='date']" position="after">
+                <field name="budget_tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/budget_analytic/views/budget_analytic_tag_views.xml
+++ b/budget_analytic/views/budget_analytic_tag_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="budget_analytic_tag_view_list" model="ir.ui.view">
+        <field name="name">budget.analytic.tag.view.tree</field>
+        <field name="model">budget.analytic.tag</field>
+        <field name="arch" type="xml">
+            <tree editable="top">
+                <field name="name"/>
+                <field name="color" widget="color_picker"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="budget_analytic_tag_action" model="ir.actions.act_window">
+        <field name="name">Budget Analytic Tag</field>
+        <field name="res_model">budget.analytic.tag</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="budget_analytic_tag_view_list"/>
+         <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Click to create a new budget tag.
+            </p>
+        </field>
+    </record>
+
+</odoo>

--- a/budget_analytic/views/budget_line_views.xml
+++ b/budget_analytic/views/budget_line_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--
+        Budget Lines
+    -->
+
+    <record id="budget_budget_line_view_form" model="ir.ui.view">
+        <field name="name">budget.budget.line.form</field>
+        <field name="model">budget.budget.line</field>
+        <field name="inherit_id" ref="budget.budget_budget_line_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='mode']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
+            <xpath expr="//group[@name='mode_computation']" position="inside">
+                <field name="analytic_account_id" attrs="{'invisible': [('mode', '!=', 'analytic')], 'required': [('mode', '=', 'analytic')]}"/>
+                <field name="analytic_budget_tag_ids" attrs="{'invisible': [('mode', '!=', 'analytic')], 'required': [('mode', '=', 'analytic')]}" widget="many2many_tags" options="{'color_field': 'color'}"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/budget_analytic/views/budget_menus.xml
+++ b/budget_analytic/views/budget_menus.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <menuitem
+        id="budget_analytic_menu"
+        name="Analytic Accounting"
+        parent="budget.budget_menu_root"
+        action="analytic.action_account_analytic_account_form"
+        groups="analytic.group_analytic_accounting"
+        sequence="10"/>
+
+    <menuitem
+        id="budget_configuration_menu_analytic"
+        name="Analytic Accounting"
+        parent="budget.budget_menu_settings"
+        groups="analytic.group_analytic_accounting"
+        sequence="10"/>
+
+            <menuitem
+                id="budget_configuration_menu_account_analytic"
+                name="Analytic Accounts"
+                parent="budget_configuration_menu_analytic"
+                action="analytic.action_account_analytic_account_form"
+                groups="analytic.group_analytic_accounting"
+                sequence="5"/>
+
+            <menuitem
+                id="budget_configuration_menu_analytic_plan"
+                name="Analytic Plans"
+                action="analytic.account_analytic_plan_action"
+                parent="budget_configuration_menu_analytic"
+                groups="analytic.group_analytic_accounting"
+                sequence="10"/>
+
+            <menuitem
+                id="budget_configuration_menu_group"
+                name="Analytic Distribution Models"
+                parent="budget_configuration_menu_analytic"
+                action="analytic.action_analytic_distribution_model"
+                groups="analytic.group_analytic_accounting"
+                sequence="15"/>
+
+    <menuitem
+        id="budget_configuration_menu_budget_tag"
+        name="Budget Analytic Tags"
+        parent="budget.budget_menu_settings"
+        action="budget_analytic_tag_action"
+        sequence="15"/>
+
+</odoo>


### PR DESCRIPTION
This commit provides a module to create a budget with theorical cost/revenue. The practical ammounts depends on the analytic entries. The budget can be split into categories for display (print) purpose.